### PR TITLE
Fix jwt plugin constructor

### DIFF
--- a/packages/gazelle_jwt/CHANGELOG.md
+++ b/packages/gazelle_jwt/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.2
+
+- Fixed secret value type in plugin constructor.
+- Fixed readme example.
+
 ## 0.1.1
 
 - Fixed pubspec description.

--- a/packages/gazelle_jwt/README.md
+++ b/packages/gazelle_jwt/README.md
@@ -22,8 +22,12 @@ Then, run `dart pub get` or ` flutter pub get`  to install  the package.
 
 Here's a quick example on how to use the GazelleJwtPlugin:
 ```dart
+import 'package:gazelle_core/gazelle_core.dart';
+import 'package:gazelle_jwt/gazelle_jwt.dart';
+
+void main() async {
   final app = GazelleApp();
-  await app.registerPlugin(GazelleJwtPlugin("supersecret"));
+  await app.registerPlugin(GazelleJwtPlugin(SecretKey("supersecret")));
 
   app
     ..post(
@@ -47,4 +51,5 @@ Here's a quick example on how to use the GazelleJwtPlugin:
     );
 
   await app.start();
+}
 ```

--- a/packages/gazelle_jwt/example/gazelle_jwt_example.dart
+++ b/packages/gazelle_jwt/example/gazelle_jwt_example.dart
@@ -6,7 +6,7 @@ void main() async {
   // Initialize your Gazelle app.
   final app = GazelleApp(port: 3000);
   // Register GazelleJwtPlugin.
-  await app.registerPlugin(GazelleJwtPlugin("supersecret"));
+  await app.registerPlugin(GazelleJwtPlugin(SecretKey("supersecret")));
 
   // Setup your routes.
   app

--- a/packages/gazelle_jwt/lib/src/gazelle_jwt_plugin.dart
+++ b/packages/gazelle_jwt/lib/src/gazelle_jwt_plugin.dart
@@ -34,17 +34,17 @@ import 'gazelle_jwt_consts.dart';
 /// ```
 class GazelleJwtPlugin implements GazellePlugin {
   /// The secret used for JWT signing and verification.
-  final String _secret;
+  final JWTKey _secret;
 
   /// The secret key derived from the secret.
-  late final SecretKey _secretKey;
+  late final JWTKey _secretKey;
 
   /// Constructs a GazelleJwtPlugin instance with the provided [secret].
   GazelleJwtPlugin(this._secret);
 
   @override
   Future<void> initialize(GazelleContext context) async {
-    _secretKey = SecretKey(_secret);
+    _secretKey = _secret;
   }
 
   /// Signs a JWT with the provided [payload].

--- a/packages/gazelle_jwt/pubspec.yaml
+++ b/packages/gazelle_jwt/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gazelle_jwt
 description: Plugin for JSON Web Token (JWT) authentication in Gazelle, providing functionality to sign, verify, and handle JWT tokens during HTTP request processing. 
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/intales/gazelle/tree/main/packages/gazelle_jwt
 
 environment:

--- a/packages/gazelle_jwt/test/gazelle_jwt_test.dart
+++ b/packages/gazelle_jwt/test/gazelle_jwt_test.dart
@@ -10,7 +10,7 @@ void main() {
       // Arrange
       const payload = {"test": "123"};
       final context = GazelleContext.create();
-      final plugin = GazelleJwtPlugin("supersecret");
+      final plugin = GazelleJwtPlugin(SecretKey("supersecret"));
       await plugin.initialize(context);
 
       // Act
@@ -24,7 +24,7 @@ void main() {
     test('Should return a request with a JWT', () async {
       // Arrange
       final context = GazelleContext.create();
-      final plugin = GazelleJwtPlugin("supersecret");
+      final plugin = GazelleJwtPlugin(SecretKey("supersecret"));
       await plugin.initialize(context);
       final token = plugin.sign({"test": "123"});
 
@@ -48,7 +48,7 @@ void main() {
     test('Should return a response when auth header is not set', () async {
       // Arrange
       final context = GazelleContext.create();
-      final plugin = GazelleJwtPlugin("supersecret");
+      final plugin = GazelleJwtPlugin(SecretKey("supersecret"));
       await plugin.initialize(context);
 
       final hook = plugin.authenticationHook;
@@ -69,7 +69,7 @@ void main() {
     test('Should return a response when header schema is invalid', () async {
       // Arrange
       final context = GazelleContext.create();
-      final plugin = GazelleJwtPlugin("supersecret");
+      final plugin = GazelleJwtPlugin(SecretKey("supersecret"));
       await plugin.initialize(context);
       final token = plugin.sign({"test": "123"});
 
@@ -94,7 +94,7 @@ void main() {
     test('Should return a response when token is invalid', () async {
       // Arrange
       final context = GazelleContext.create();
-      final plugin = GazelleJwtPlugin("supersecret");
+      final plugin = GazelleJwtPlugin(SecretKey("supersecret"));
       await plugin.initialize(context);
       final token = plugin.sign({"test": "123"});
 
@@ -119,7 +119,7 @@ void main() {
     test('Should integrate with gazelle core', () async {
       // Arrange
       final app = GazelleApp();
-      await app.registerPlugin(GazelleJwtPlugin("supersecret"));
+      await app.registerPlugin(GazelleJwtPlugin(SecretKey("supersecret")));
 
       app
         ..post(


### PR DESCRIPTION
Constructor now asks for a JwtKey instance.
This is more generic and enables the developer
to use whatever type of JwtKey he/she wants.