### PR TITLE
Cli create command update

### DIFF
--- a/packages/gazelle_cli/lib/commands/create/create.dart
+++ b/packages/gazelle_cli/lib/commands/create/create.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:cli_spin/cli_spin.dart';
 
+import '../../commons/functions/load_project_configuration.dart';
 import 'create_project.dart';
 import 'create_route.dart';
 
@@ -83,22 +84,24 @@ class _CreateRouteCommand extends Command {
 
   @override
   void run() async {
-    stdout.writeln("✨ What would you like to name your new route? 🚀");
-    String? routeName = stdin.readLineSync();
-    while (routeName == null || routeName == "") {
-      stdout.writeln("⚠ Please provide a name for your route to proceed:");
-      routeName = stdin.readLineSync();
-    }
-    stdout.writeln();
-
-    routeName = routeName.replaceAll(RegExp(r'\s+'), "_").toLowerCase();
-
-    final spinner = CliSpin(
-      text: "Creating $routeName route...",
-      spinner: CliSpinners.dots,
-    ).start();
-
+    CliSpin spinner = CliSpin();
     try {
+      await loadProjectConfiguration();
+      stdout.writeln("✨ What would you like to name your new route? 🚀");
+      String? routeName = stdin.readLineSync();
+      while (routeName == null || routeName == "") {
+        stdout.writeln("⚠ Please provide a name for your route to proceed:");
+        routeName = stdin.readLineSync();
+      }
+      stdout.writeln();
+
+      routeName = routeName.replaceAll(RegExp(r'\s+'), "_").toLowerCase();
+
+      spinner = CliSpin(
+        text: "Creating $routeName route...",
+        spinner: CliSpinners.dots,
+      ).start();
+
       final directory = Directory.current;
       final path = "${directory.path}/lib";
 
@@ -110,6 +113,9 @@ class _CreateRouteCommand extends Command {
       spinner.success(
         "$routeName route created 🚀",
       );
+    } on LoadProjectConfigurationGazelleNotFoundError catch (e) {
+      spinner.fail(e.errorMessage);
+      exit(e.errorCode);
     } on Exception catch (e) {
       spinner.fail(e.toString());
       exit(2);

--- a/packages/gazelle_cli/lib/commands/create/create.dart
+++ b/packages/gazelle_cli/lib/commands/create/create.dart
@@ -33,7 +33,7 @@ class CreateCommand extends Command {
 
     try {
       final result = await createProject(
-        projectName,
+        projectName: projectName,
         path: Directory.current.path,
       );
 

--- a/packages/gazelle_cli/lib/commands/create/create.dart
+++ b/packages/gazelle_cli/lib/commands/create/create.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';

--- a/packages/gazelle_cli/lib/commands/create/create.dart
+++ b/packages/gazelle_cli/lib/commands/create/create.dart
@@ -1,9 +1,11 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:cli_spin/cli_spin.dart';
 
 import 'create_project.dart';
+import 'create_route.dart';
 
 /// CLI command to create a new Gazelle project.
 class CreateCommand extends Command {
@@ -14,7 +16,22 @@ class CreateCommand extends Command {
   String get description => "Creates a new Gazelle project.";
 
   /// Creates a [CreateCommand].
-  CreateCommand();
+  CreateCommand() {
+    addSubcommand(_CreateProjectCommand());
+    addSubcommand(_CreateRouteCommand());
+  }
+}
+
+/// CLI command to create a new Gazelle project.
+class _CreateProjectCommand extends Command {
+  @override
+  String get name => "project";
+
+  @override
+  String get description => "Creates a new Gazelle project.";
+
+  /// Creates a [_CreateProjectCommand].
+  _CreateProjectCommand();
 
   @override
   void run() async {
@@ -45,6 +62,49 @@ class CreateCommand extends Command {
     } on CreateProjectError catch (e) {
       spinner.fail(e.message);
       exit(2);
+    } on Exception catch (e) {
+      spinner.fail(e.toString());
+      exit(2);
+    }
+  }
+}
+
+/// CLI command to create a new Gazelle project.
+class _CreateRouteCommand extends Command {
+  @override
+  String get name => "route";
+
+  @override
+  String get description =>
+      "Creates a new route inside the current Gazelle project.";
+
+  _CreateRouteCommand();
+
+  @override
+  void run() async {
+    stdout.writeln("✨ What would you like to name your new route? 🚀");
+    String? routeName = stdin.readLineSync();
+    while (routeName == null || routeName == "") {
+      stdout.writeln("⚠ Please provide a name for your route to proceed:");
+      routeName = stdin.readLineSync();
+    }
+    stdout.writeln();
+
+    final spinner = CliSpin(
+      text: "Creating $routeName route...",
+      spinner: CliSpinners.dots,
+    ).start();
+
+    try {
+      final directory = Directory.current;
+      final result = await createRoute(
+        routeName: routeName,
+        path: "${directory.path}/lib/routes",
+      );
+
+      spinner.success(
+        "$routeName route created 🚀\n💡To navigate to your project run \"cd ${result.routeFilePath.split("/").last}\"",
+      );
     } on Exception catch (e) {
       spinner.fail(e.toString());
       exit(2);

--- a/packages/gazelle_cli/lib/commands/create/create.dart
+++ b/packages/gazelle_cli/lib/commands/create/create.dart
@@ -14,36 +14,34 @@ class CreateCommand extends Command {
   String get description => "Creates a new Gazelle project.";
 
   /// Creates a [CreateCommand].
-  CreateCommand() {
-    argParser.addOption(
-      "name",
-      abbr: "n",
-      help: "The name of the project you want to build.",
-    );
-    argParser.addOption(
-      "path",
-      abbr: "p",
-      help: "The path where you want to build the project.",
-    );
-  }
+  CreateCommand();
 
   @override
   void run() async {
+    stdout.writeln("✨ What would you like to name your new project? 🚀");
+    String? projectName = stdin.readLineSync();
+    while (projectName == null || projectName == "") {
+      stdout.writeln("⚠ Please provide a name for your project to proceed:");
+      projectName = stdin.readLineSync();
+    }
+    stdout.writeln();
+
     final spinner = CliSpin(
-      text: "Creating Gazelle project...",
+      text: "Creating $projectName project...",
       spinner: CliSpinners.dots,
     ).start();
 
-    final nameOption = argResults?.option("name") ??
-        argResults?.rest.firstOrNull ??
-        "gazelle_app";
-    final pathOption = argResults?.option("path");
-
     try {
-      final result = await createProject(nameOption, path: pathOption);
-      spinner.success(
-        "$result project created!\nRun `gazelle run $result` to test it.",
+      final result = await createProject(
+        projectName,
+        path: Directory.current.path,
       );
+
+      spinner.success(
+        "$projectName project created 🚀\n💡To navigate to your project run \"cd ${result.split("/").last}\"\n💡Then, use \"gazelle run\" to execute it!",
+      );
+
+      Directory.current = result;
     } on CreateProjectError catch (e) {
       spinner.fail(e.message);
       exit(2);

--- a/packages/gazelle_cli/lib/commands/create/create.dart
+++ b/packages/gazelle_cli/lib/commands/create/create.dart
@@ -42,6 +42,8 @@ class _CreateProjectCommand extends Command {
     }
     stdout.writeln();
 
+    projectName = projectName.replaceAll(RegExp(r'\s+'), "_").toLowerCase();
+
     final spinner = CliSpin(
       text: "Creating $projectName project...",
       spinner: CliSpinners.dots,
@@ -89,6 +91,8 @@ class _CreateRouteCommand extends Command {
     }
     stdout.writeln();
 
+    routeName = routeName.replaceAll(RegExp(r'\s+'), "_").toLowerCase();
+
     final spinner = CliSpin(
       text: "Creating $routeName route...",
       spinner: CliSpinners.dots,
@@ -96,13 +100,15 @@ class _CreateRouteCommand extends Command {
 
     try {
       final directory = Directory.current;
-      final result = await createRoute(
+      final path = "${directory.path}/lib";
+
+      await createRoute(
         routeName: routeName,
-        path: "${directory.path}/lib/routes",
+        path: path,
       );
 
       spinner.success(
-        "$routeName route created 🚀\n💡To navigate to your project run \"cd ${result.routeFilePath.split("/").last}\"",
+        "$routeName route created 🚀",
       );
     } on Exception catch (e) {
       spinner.fail(e.toString());

--- a/packages/gazelle_cli/lib/commands/create/create_handler.dart
+++ b/packages/gazelle_cli/lib/commands/create/create_handler.dart
@@ -2,8 +2,23 @@ import 'dart:io';
 
 import 'package:dart_style/dart_style.dart';
 
+/// Represents the result of [createHandler] function.
+class CreateHandlerResult {
+  /// Where the handler has been created.
+  final String handlerFilePath;
+
+  /// The name of the handler.
+  final String handlerName;
+
+  /// Creates a [CreateHandlerResult].
+  const CreateHandlerResult({
+    required this.handlerFilePath,
+    required this.handlerName,
+  });
+}
+
 /// Creates an handler for a Gazelle project.
-Future<String> createHandler({
+Future<CreateHandlerResult> createHandler({
   required String routeName,
   required String httpMethod,
   required String path,
@@ -47,8 +62,13 @@ GazelleResponse $handlerName(
 
   final handlerFileName =
       "$path/${routeName.toLowerCase()}_${httpMethod.toLowerCase()}.dart";
-  return File(handlerFileName)
+  final handlerFilePath = await File(handlerFileName)
       .create(recursive: true)
       .then((file) => file.writeAsString(DartFormatter().format(handler)))
       .then((file) => file.path);
+
+  return CreateHandlerResult(
+    handlerFilePath: handlerFilePath,
+    handlerName: handlerName,
+  );
 }

--- a/packages/gazelle_cli/lib/commands/create/create_handler.dart
+++ b/packages/gazelle_cli/lib/commands/create/create_handler.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:dart_style/dart_style.dart';
+
+/// Creates an handler for a Gazelle project.
+Future<String> createHandler({
+  required String routeName,
+  required String httpMethod,
+  required String path,
+}) async {
+  final routeNameParts = routeName.split("_");
+
+  String handlerName = "";
+  for (var i = 0; i < routeNameParts.length; i++) {
+    final part = routeNameParts[i];
+    if (i == 0) {
+      handlerName += part.toLowerCase();
+      continue;
+    }
+    handlerName += "${part[0].toUpperCase()}${part.substring(1)}";
+  }
+
+  handlerName += switch (httpMethod) {
+    "GET" => "Get",
+    "POST" => "Post",
+    "PUT" => "Put",
+    "PATCH" => "Patch",
+    "DELETE" => "Delete",
+    _ => throw "Unexpected error",
+  };
+
+  final handler = """
+import 'package:gazelle_core/gazelle_core.dart';
+
+GazelleResponse $handlerName(
+  GazelleContext context,
+  GazelleRequest request,
+  GazelleResponse response,
+) {
+  return GazelleResponse(
+    statusCode: GazelleHttpStatusCode.success.ok_200,
+    body: "Hello, World!",
+  );
+}
+  """
+      .trim();
+
+  final handlerFileName =
+      "$path/${routeName.toLowerCase()}_${httpMethod.toLowerCase()}.dart";
+  return File(handlerFileName)
+      .create(recursive: true)
+      .then((file) => file.writeAsString(DartFormatter().format(handler)))
+      .then((file) => file.path);
+}

--- a/packages/gazelle_cli/lib/commands/create/create_handler.dart
+++ b/packages/gazelle_cli/lib/commands/create/create_handler.dart
@@ -61,7 +61,7 @@ GazelleResponse $handlerName(
       .trim();
 
   final handlerFileName =
-      "$path/${routeName.toLowerCase()}_${httpMethod.toLowerCase()}.dart";
+      "$path/${routeName.toLowerCase()}_${httpMethod.toLowerCase()}_handler.dart";
   final handlerFilePath = await File(handlerFileName)
       .create(recursive: true)
       .then((file) => file.writeAsString(DartFormatter().format(handler)))

--- a/packages/gazelle_cli/lib/commands/create/create_hook.dart
+++ b/packages/gazelle_cli/lib/commands/create/create_hook.dart
@@ -1,0 +1,115 @@
+import 'dart:io';
+
+import 'package:dart_style/dart_style.dart';
+
+/// The result of [createHook] function.
+class CreateHookResult {
+  /// The path of the create hook file.
+  final String hookFilePath;
+
+  /// The name of the created hook.
+  final String hookName;
+
+  /// Creates a [CreateHookResult].
+  const CreateHookResult({
+    required this.hookFilePath,
+    required this.hookName,
+  });
+}
+
+/// Enumerates available hook types.
+enum CreateHookType {
+  /// Pre request hook.
+  preRequest,
+
+  /// Post request hook.
+  postResponse;
+
+  @override
+  String toString() => switch (this) {
+        CreateHookType.preRequest => "pre_request",
+        CreateHookType.postResponse => "post_response",
+      };
+}
+
+/// Creates a new hook.
+Future<CreateHookResult> createHook({
+  required String hookName,
+  required CreateHookType hookType,
+  required String path,
+}) async {
+  final routeNameParts = hookName.split("_");
+
+  String codeHookName = "";
+  for (var i = 0; i < routeNameParts.length; i++) {
+    final part = routeNameParts[i];
+    if (i == 0) {
+      codeHookName += part.toLowerCase();
+      continue;
+    }
+    codeHookName += "${part[0].toUpperCase()}${part.substring(1)}";
+  }
+  codeHookName += switch (hookType) {
+    CreateHookType.preRequest => "PreRequest",
+    CreateHookType.postResponse => "PostResponse",
+  };
+  codeHookName += "Hook";
+
+  final hook = switch (hookType) {
+    CreateHookType.preRequest => _createPreRequestHook(
+        hookName: codeHookName,
+      ),
+    CreateHookType.postResponse => _createPostResponseHook(
+        hookName: codeHookName,
+      ),
+  };
+
+  final hookFileName = "$path/${hookName}_$hookType.dart";
+
+  final hookFile = await File(hookFileName)
+      .create(recursive: true)
+      .then((file) => file.writeAsString(DartFormatter().format(hook)));
+
+  return CreateHookResult(
+    hookFilePath: hookFile.path,
+    hookName: codeHookName,
+  );
+}
+
+String _createPreRequestHook({
+  required String hookName,
+}) {
+  final hook = """
+import 'package:gazelle_core/gazelle_core.dart';
+
+final $hookName = GazellePreReqestHook(
+  (context, request, response) async {
+    // TODO: Write an awesome hook!
+
+    return (request, response);
+  },
+);
+  """
+      .trim();
+
+  return hook;
+}
+
+String _createPostResponseHook({
+  required String hookName,
+}) {
+  final hook = """
+import 'package:gazelle_core/gazelle_core.dart';
+
+final $hookName = GazellePostResponseHook(
+  (context, request, response) async {
+    // TODO: Write an awesome hook!
+
+    return (request, response);
+  },
+);
+  """
+      .trim();
+
+  return hook;
+}

--- a/packages/gazelle_cli/lib/commands/create/create_project.dart
+++ b/packages/gazelle_cli/lib/commands/create/create_project.dart
@@ -33,6 +33,9 @@ doc/api/
 
 .flutter-plugins
 .flutter-plugins-dependencies
+
+# Gazelle temporary files
+.tmp/
 """;
 
 String _getMainFile({
@@ -69,6 +72,8 @@ dependencies:
 dev_dependencies:
   lints: ">=2.1.0 <4.0.0"
   test: ^1.24.0
+
+gazelle:
 """;
 
 String _getEntryPoint(String projectName) => """
@@ -102,18 +107,6 @@ Future<String> createProject({
 
   final libPath = "$projectPath/lib";
   final binPath = "$projectPath/bin";
-
-  final projectNameParts = projectName.split("_");
-
-  String codeProjectName = "";
-  for (var i = 0; i < projectNameParts.length; i++) {
-    final part = projectNameParts[i];
-    if (i == 0) {
-      codeProjectName += part.toLowerCase();
-      continue;
-    }
-    codeProjectName += "${part[0].toUpperCase()}${part.substring(1)}";
-  }
 
   final helloGazelleRoute = await createRoute(
     routeName: "hello_gazelle",

--- a/packages/gazelle_cli/lib/commands/create/create_project.dart
+++ b/packages/gazelle_cli/lib/commands/create/create_project.dart
@@ -117,7 +117,7 @@ Future<String> createProject({
 
   final helloGazelleRoute = await createRoute(
     routeName: "hello_gazelle",
-    path: "$libPath/routes",
+    path: libPath,
   );
 
   final main = _getMainFile(
@@ -130,7 +130,7 @@ Future<String> createProject({
 
   await File("$projectPath/pubspec.yaml")
       .create(recursive: true)
-      .then((file) => file.writeAsString(_getPubspecTemplate(codeProjectName)));
+      .then((file) => file.writeAsString(_getPubspecTemplate(projectName)));
 
   await File("$projectPath/.gitignore")
       .create(recursive: true)

--- a/packages/gazelle_cli/lib/commands/create/create_project.dart
+++ b/packages/gazelle_cli/lib/commands/create/create_project.dart
@@ -89,15 +89,11 @@ class CreateProjectError {
 /// Creates a new Gazelle project.
 ///
 /// Throws a [CreateProjectError] if project already exists.
-Future<String> createProject(
-  String projectName, {
-  String? path,
+Future<String> createProject({
+  required String projectName,
+  required String path,
 }) async {
-  final nameOption = projectName;
-  final pathOption = path;
-
-  final completePath =
-      pathOption != null ? "$pathOption/$nameOption" : nameOption;
+  final completePath = "$path/$projectName";
   if (await Directory(completePath).exists()) {
     throw CreateProjectError();
   }
@@ -106,19 +102,19 @@ Future<String> createProject(
 
   await File("$completePath/pubspec.yaml")
       .create(recursive: true)
-      .then((file) => file.writeAsString(_getPubspecTemplate(nameOption)));
+      .then((file) => file.writeAsString(_getPubspecTemplate(projectName)));
 
   await File("$completePath/.gitignore")
       .create(recursive: true)
       .then((file) => file.writeAsString(_gitignore));
 
-  await File("$completePath/lib/$nameOption.dart")
+  await File("$completePath/lib/$projectName.dart")
       .create(recursive: true)
       .then((file) => file.writeAsString(_mainTemplate));
 
-  await File("$completePath/bin/$nameOption.dart")
+  await File("$completePath/bin/$projectName.dart")
       .create(recursive: true)
-      .then((file) => file.writeAsString(_getEntryPoint(nameOption)));
+      .then((file) => file.writeAsString(_getEntryPoint(projectName)));
 
   await Process.run(
     "dart",

--- a/packages/gazelle_cli/lib/commands/create/create_project.dart
+++ b/packages/gazelle_cli/lib/commands/create/create_project.dart
@@ -142,7 +142,7 @@ Future<String> createProject({
 
   await File("$binPath/$projectName.dart")
       .create(recursive: true)
-      .then((file) => file.writeAsString(_getEntryPoint(codeProjectName)));
+      .then((file) => file.writeAsString(_getEntryPoint(projectName)));
 
   await Process.run(
     "dart",

--- a/packages/gazelle_cli/lib/commands/create/create_project.dart
+++ b/packages/gazelle_cli/lib/commands/create/create_project.dart
@@ -36,17 +36,24 @@ const _mainTemplate = """
 import 'package:gazelle_core/gazelle_core.dart';
 
 Future<void> runApp(List<String> args) async {
-  final app = GazelleApp();
-
-  app.get("/", (request, response) async {
-    return response.copyWith(
-      statusCode: 200,
-      body: "Hello, Gazelle!",
+  try {
+    final app = GazelleApp(
+      routes: [
+        GazelleRoute(
+          name: "hello_gazelle",
+          get: (context, request, response) => GazelleResponse(
+            statusCode: GazelleHttpStatusCode.success.ok_200,
+            body: "Hello, Gazelle!",
+          ),
+        ),
+      ],
     );
-  });
 
-  await app.start();
-  print('Server is running at http://\${app.address}:\${app.port}');
+    await app.start();
+    print("Gazelle listening at \${app.serverAddress}");
+  } catch (e) {
+    print("Failed to start the server: \$e");
+  }
 }
 """;
 
@@ -59,7 +66,7 @@ environment:
   sdk: ^$dartSdkVersion
 
 dependencies:
-  gazelle_core: ^0.2.0
+  gazelle_core: ^0.3.0
 
 dev_dependencies:
   lints: ">=2.1.0 <4.0.0"

--- a/packages/gazelle_cli/lib/commands/create/create_project.dart
+++ b/packages/gazelle_cli/lib/commands/create/create_project.dart
@@ -36,24 +36,20 @@ const _mainTemplate = """
 import 'package:gazelle_core/gazelle_core.dart';
 
 Future<void> runApp(List<String> args) async {
-  try {
-    final app = GazelleApp(
-      routes: [
-        GazelleRoute(
-          name: "hello_gazelle",
-          get: (context, request, response) => GazelleResponse(
-            statusCode: GazelleHttpStatusCode.success.ok_200,
-            body: "Hello, Gazelle!",
-          ),
+  final app = GazelleApp(
+    routes: [
+      GazelleRoute(
+        name: "hello_gazelle",
+        get: (context, request, response) => GazelleResponse(
+          statusCode: GazelleHttpStatusCode.success.ok_200,
+          body: "Hello, Gazelle!",
         ),
-      ],
-    );
+      ),
+    ],
+  );
 
-    await app.start();
-    print("Gazelle listening at \${app.serverAddress}");
-  } catch (e) {
-    print("Failed to start the server: \$e");
-  }
+  await app.start();
+  print("Gazelle listening at \${app.serverAddress}");
 }
 """;
 

--- a/packages/gazelle_cli/lib/commands/create/create_route.dart
+++ b/packages/gazelle_cli/lib/commands/create/create_route.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:dart_style/dart_style.dart';
+
+import 'create_handler.dart';
+
+/// Represents the result of [createRoute] function.
+class CreateRouteResult {
+  /// The path of the created route file.
+  final String routeFilePath;
+
+  /// The name of the created route.
+  final String routeName;
+
+  /// Creates a [CreateRouteResult].
+  const CreateRouteResult({
+    required this.routeFilePath,
+    required this.routeName,
+  });
+}
+
+/// Creates a route for a Gazelle project.
+Future<CreateRouteResult> createRoute({
+  required String routeName,
+  required String path,
+}) async {
+  final routeNameParts = routeName.split("_");
+
+  String codeRouteName = "";
+  for (var i = 0; i < routeNameParts.length; i++) {
+    final part = routeNameParts[i];
+    if (i == 0) {
+      codeRouteName += part.toLowerCase();
+      continue;
+    }
+    codeRouteName += "${part[0].toUpperCase()}${part.substring(1)}";
+  }
+
+  final handlerPath = "$path/handlers";
+  final handler = await createHandler(
+    routeName: routeName,
+    httpMethod: "GET",
+    path: handlerPath,
+  );
+
+  final handlerImportDirectivePath =
+      handler.handlerFilePath.replaceAll(path, "").substring(1);
+
+  final route = """
+import 'package:gazelle_core/gazelle_core.dart';
+import '$handlerImportDirectivePath';
+
+final ${codeRouteName}Route = GazelleRoute(
+  name: $routeName,
+  get: ${handler.handlerName},
+);
+  """
+      .trim();
+
+  final routeFileName = "$path/$routeName.dart";
+  final routeFile = await File(routeFileName)
+      .create(recursive: true)
+      .then((file) => file.writeAsString(DartFormatter().format(route)));
+
+  return CreateRouteResult(
+    routeFilePath: routeFile.path,
+    routeName: routeName,
+  );
+}

--- a/packages/gazelle_cli/lib/commands/create/create_route.dart
+++ b/packages/gazelle_cli/lib/commands/create/create_route.dart
@@ -35,6 +35,7 @@ Future<CreateRouteResult> createRoute({
     }
     codeRouteName += "${part[0].toUpperCase()}${part.substring(1)}";
   }
+  codeRouteName += "Route";
 
   final handlerPath = "$path/handlers";
   final handler = await createHandler(
@@ -50,20 +51,20 @@ Future<CreateRouteResult> createRoute({
 import 'package:gazelle_core/gazelle_core.dart';
 import '$handlerImportDirectivePath';
 
-final ${codeRouteName}Route = GazelleRoute(
-  name: $routeName,
+final $codeRouteName = GazelleRoute(
+  name: "$routeName",
   get: ${handler.handlerName},
 );
   """
       .trim();
 
-  final routeFileName = "$path/$routeName.dart";
+  final routeFileName = "$path/${routeName}_route.dart";
   final routeFile = await File(routeFileName)
       .create(recursive: true)
       .then((file) => file.writeAsString(DartFormatter().format(route)));
 
   return CreateRouteResult(
     routeFilePath: routeFile.path,
-    routeName: routeName,
+    routeName: codeRouteName,
   );
 }

--- a/packages/gazelle_cli/lib/commands/create/create_route.dart
+++ b/packages/gazelle_cli/lib/commands/create/create_route.dart
@@ -37,7 +37,8 @@ Future<CreateRouteResult> createRoute({
   }
   codeRouteName += "Route";
 
-  final handlerPath = "$path/handlers";
+  final routeDirectory = "$path/routes/${routeName}_route";
+  final handlerPath = "$routeDirectory/handlers";
   final handler = await createHandler(
     routeName: routeName,
     httpMethod: "GET",
@@ -45,20 +46,20 @@ Future<CreateRouteResult> createRoute({
   );
 
   final handlerImportDirectivePath =
-      handler.handlerFilePath.replaceAll(path, "").substring(1);
+      handler.handlerFilePath.replaceAll(routeDirectory, "").substring(1);
 
   final route = """
 import 'package:gazelle_core/gazelle_core.dart';
 import '$handlerImportDirectivePath';
 
-final $codeRouteName = GazelleRoute(
+const $codeRouteName = GazelleRoute(
   name: "$routeName",
   get: ${handler.handlerName},
 );
   """
       .trim();
 
-  final routeFileName = "$path/${routeName}_route.dart";
+  final routeFileName = "$routeDirectory/${routeName}_route.dart";
   final routeFile = await File(routeFileName)
       .create(recursive: true)
       .then((file) => file.writeAsString(DartFormatter().format(route)));

--- a/packages/gazelle_cli/lib/commands/dockerize/dockerize.dart
+++ b/packages/gazelle_cli/lib/commands/dockerize/dockerize.dart
@@ -51,7 +51,7 @@ class DockerizeCommand extends Command {
     try {
       final dockerfile = await dockerize(exposedPort: exposedPort);
       spinner.success("Dockerfile created at ${dockerfile.path}");
-    } on LoadProjectConfigurationError catch (e) {
+    } on LoadProjectConfigurationPubspecNotFoundError catch (e) {
       spinner.fail(e.errorMessage);
       exit(e.errorCode);
     } on Exception catch (e) {

--- a/packages/gazelle_cli/lib/commands/run/run.dart
+++ b/packages/gazelle_cli/lib/commands/run/run.dart
@@ -53,7 +53,7 @@ class RunCommand extends Command {
     late final ProjectConfiguration config;
     try {
       config = await loadProjectConfiguration(path: pathOption);
-    } on LoadProjectConfigurationError catch (e) {
+    } on LoadProjectConfigurationPubspecNotFoundError catch (e) {
       print(e.errorMessage);
       exit(e.errorCode);
     } catch (e) {

--- a/packages/gazelle_cli/lib/commons/entities/stdin_broadcast.dart
+++ b/packages/gazelle_cli/lib/commons/entities/stdin_broadcast.dart
@@ -23,13 +23,13 @@ Stream<String> _createBroadcastStdin() {
   stdin.echoMode = false;
   stdin.lineMode = false;
 
-  var controller = StreamController<String>.broadcast(
-    onListen: () => stdin.transform(utf8.decoder).listen(controller.add),
+  final controller = StreamController<String>.broadcast(
     onCancel: () {
       stdin.lineMode = true;
       stdin.echoMode = true;
     },
   );
+  stdin.transform(utf8.decoder).listen(controller.add);
 
   return controller.stream;
 }

--- a/packages/gazelle_cli/lib/commons/functions/load_project_configuration.dart
+++ b/packages/gazelle_cli/lib/commons/functions/load_project_configuration.dart
@@ -3,32 +3,54 @@ import 'package:yaml/yaml.dart';
 
 import '../entities/project_configuration.dart';
 
-/// Reporesents an error that is thrown when project configuration cannot be loaded.
-class LoadProjectConfigurationError {
+/// Reporesents an error that is thrown when project configuration cannot be found.
+class LoadProjectConfigurationPubspecNotFoundError {
   /// Error code.
   final int errorCode;
 
   /// Error message.
   final String errorMessage;
 
-  /// Builds a [LoadProjectConfigurationError] instance.
-  const LoadProjectConfigurationError({
-    this.errorCode = 1,
+  /// Builds a [LoadProjectConfigurationPubspecNotFoundError] instance.
+  const LoadProjectConfigurationPubspecNotFoundError({
+    this.errorCode = 2,
     this.errorMessage =
         "Unable to find pubspec.yaml file in current directory.",
   });
 }
 
+/// Reporesents an error that is thrown when project configuration does not contain the gazelle prop.
+class LoadProjectConfigurationGazelleNotFoundError {
+  /// Error code.
+  final int errorCode;
+
+  /// Error message.
+  final String errorMessage;
+
+  /// Builds a [LoadProjectConfigurationGazelleNotFoundError] instance.
+  const LoadProjectConfigurationGazelleNotFoundError({
+    this.errorCode = 2,
+    this.errorMessage =
+        "Unable to find gazelle property inside the pubspec.yaml file.",
+  });
+}
+
 /// Loads configuration file from project `pubspec.yaml` file.
 ///
-/// Throws [LoadProjectConfigurationError] if `pubspec.yaml` is not found.
+/// Throws [LoadProjectConfigurationPubspecNotFoundError] if `pubspec.yaml` is not found.
 Future<ProjectConfiguration> loadProjectConfiguration({String? path}) async {
   final directory = Directory(path ?? Directory.current.path);
   final pubspecPath = "${directory.path}/pubspec.yaml";
   final pubspec = File(pubspecPath);
 
-  if (!await pubspec.exists()) throw const LoadProjectConfigurationError();
+  if (!await pubspec.exists()) {
+    throw const LoadProjectConfigurationPubspecNotFoundError();
+  }
 
-  final yaml = loadYaml(await pubspec.readAsString());
+  final yaml = loadYaml(await pubspec.readAsString()) as YamlMap;
+
+  if (!yaml.containsKey("gazelle")) {
+    throw const LoadProjectConfigurationGazelleNotFoundError();
+  }
   return ProjectConfiguration.fromYaml(yaml);
 }

--- a/packages/gazelle_cli/pubspec.yaml
+++ b/packages/gazelle_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gazelle_cli
 description: A CLI tool to manage applications built with Gazelle framework.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/intales/gazelle/tree/main/packages/gazelle_cli
 
 environment:

--- a/packages/gazelle_cli/test/commands/create/create_handler_test.dart
+++ b/packages/gazelle_cli/test/commands/create/create_handler_test.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:gazelle_cli/commands/create/create_handler.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CreateHandler tests', () {
+    test('Should create a handler file', () async {
+      // Arrange
+      final tmpDirPath = "tmp/create_handler_test";
+      Directory tmpDir = Directory(tmpDirPath);
+      if (await tmpDir.exists()) {
+        await tmpDir.delete(recursive: true);
+      }
+      tmpDir = await Directory(tmpDirPath).create(recursive: true);
+
+      // Act
+      final result = await createHandler(
+        routeName: "hello_world",
+        httpMethod: "GET",
+        path: tmpDirPath,
+      );
+
+      // Assert
+      expect(File(result).existsSync(), isTrue);
+    });
+  });
+}

--- a/packages/gazelle_cli/test/commands/create/create_hook_test.dart
+++ b/packages/gazelle_cli/test/commands/create/create_hook_test.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:gazelle_cli/commands/create/create_hook.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CreateHook tests', () {
+    test('Should create a pre-request hook', () async {
+      // Arrange
+      final tmpDirPath = "tmp/create_pre_request_hook_test";
+      Directory tmpDir = Directory(tmpDirPath);
+      if (await tmpDir.exists()) {
+        await tmpDir.delete(recursive: true);
+      }
+      tmpDir = await Directory(tmpDirPath).create(recursive: true);
+
+      // Act
+      final result = await createHook(
+        hookName: "authentication",
+        hookType: CreateHookType.preRequest,
+        path: tmpDirPath,
+      );
+
+      // Assert
+      expect(File(result.hookFilePath).existsSync(), isTrue);
+      expect(result.hookName, "authenticationPreRequestHook");
+
+      // Clean up
+      await tmpDir.delete(recursive: true);
+    });
+
+    test('Should create a post-response hook', () async {
+      // Arrange
+      final tmpDirPath = "tmp/create_post_response_hook_test";
+      Directory tmpDir = Directory(tmpDirPath);
+      if (await tmpDir.exists()) {
+        await tmpDir.delete(recursive: true);
+      }
+      tmpDir = await Directory(tmpDirPath).create(recursive: true);
+
+      // Act
+      final result = await createHook(
+        hookName: "custom_header",
+        hookType: CreateHookType.postResponse,
+        path: tmpDirPath,
+      );
+
+      // Assert
+      expect(File(result.hookFilePath).existsSync(), isTrue);
+      expect(result.hookName, "customHeaderPostResponseHook");
+
+      // Clean up
+      await tmpDir.delete(recursive: true);
+    });
+  });
+}

--- a/packages/gazelle_cli/test/commands/create/create_project_test.dart
+++ b/packages/gazelle_cli/test/commands/create/create_project_test.dart
@@ -18,7 +18,7 @@ void main() {
       await Directory(path).create(recursive: true);
 
       // Act
-      final result = await createProject("test", path: path);
+      final result = await createProject(projectName: "test", path: path);
 
       // Assert
       expect(File("$result/pubspec.yaml").existsSync(), isTrue);

--- a/packages/gazelle_cli/test/commands/create/create_route_test.dart
+++ b/packages/gazelle_cli/test/commands/create/create_route_test.dart
@@ -1,13 +1,13 @@
 import 'dart:io';
 
-import 'package:gazelle_cli/commands/create/create_handler.dart';
+import 'package:gazelle_cli/commands/create/create_route.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('CreateHandler tests', () {
-    test('Should create a handler file', () async {
+  group('CreateRoute tests', () {
+    test('Should create a route', () async {
       // Arrange
-      final tmpDirPath = "tmp/create_handler_test";
+      final tmpDirPath = "tmp/create_route_test";
       Directory tmpDir = Directory(tmpDirPath);
       if (await tmpDir.exists()) {
         await tmpDir.delete(recursive: true);
@@ -15,15 +15,13 @@ void main() {
       tmpDir = await Directory(tmpDirPath).create(recursive: true);
 
       // Act
-      final result = await createHandler(
+      final result = await createRoute(
         routeName: "hello_world",
-        httpMethod: "GET",
         path: tmpDirPath,
       );
 
       // Assert
-      expect(result.handlerName, "helloWorldGet");
-      expect(File(result.handlerFilePath).existsSync(), isTrue);
+      expect(File(result.routeFilePath).existsSync(), isTrue);
 
       // Clean up
       await tmpDir.delete(recursive: true);

--- a/packages/gazelle_cli/test/commons/functions/load_project_configuration_test.dart
+++ b/packages/gazelle_cli/test/commons/functions/load_project_configuration_test.dart
@@ -1,14 +1,36 @@
+import 'dart:io';
+
+import 'package:gazelle_cli/commands/create/create_project.dart';
 import 'package:gazelle_cli/commons/functions/load_project_configuration.dart';
 import 'package:test/test.dart';
 
 void main() {
   group("LoadProjectConfiguration tests", () {
     test("Should throw error when pubspec doesn't exist", () async {
+      // Arrange
+      const path = "tmp/load_project_configuration_tests";
+
+      try {
+        await Directory(path).delete(recursive: true);
+      } catch (_) {
+        print("$path does not exist, creating it now.");
+      }
+
+      await Directory(path).create(recursive: true);
+
+      final projectPath = await createProject(
+        projectName: "test_project",
+        path: path,
+      );
+
       // Act
-      final result = await loadProjectConfiguration();
+      final result = await loadProjectConfiguration(path: projectPath);
 
       // Assert
-      expect(result.name, "gazelle_cli");
+      expect(result.name, "test_project");
+
+      // Tear down
+      await Directory(path).delete(recursive: true);
     });
   });
 }


### PR DESCRIPTION
# Description
The `create` command now has 2 subcommands to use:
- `create project` :  Creates a new Gazelle project
- `create route`: Creates a new route inside a Gazelle project

## Additional notes
`loadProjectConfiguration` now checks if the current project is a real Gazelle project.