### PR TITLE
fix(gazelle_cli): Codegen fix

### DIFF
--- a/packages/gazelle_cli/lib/commands/codegen/codegen.dart
+++ b/packages/gazelle_cli/lib/commands/codegen/codegen.dart
@@ -41,6 +41,7 @@ class _CodegenModelsCommand extends Command {
     CliSpin spinner = CliSpin();
     try {
       final projectConfiguration = await loadProjectConfiguration();
+      Directory.current = projectConfiguration.path;
 
       spinner = CliSpin(
         text: "Generating models...",


### PR DESCRIPTION
Codegen models couldn't work in a full-stack
project because the working directory of
the `codegen models` command was not set at
the root of the project.

Closes #53