### PR TITLE
fix(gazelle_core): request metadata

### DIFF
--- a/packages/gazelle_core/lib/src/gazelle_app.dart
+++ b/packages/gazelle_core/lib/src/gazelle_app.dart
@@ -203,11 +203,9 @@ class GazelleApp {
         bodyStream: hookRequest.bodyStream,
         method: hookRequest.method,
         headers: [...request.headers, ...hookRequest.headers],
-        metadata: {...request.metadata, ...hookRequest.metadata},
         pathParameters: hookRequest.pathParameters,
       );
       response = GazelleResponse(
-        metadata: {...response.metadata, ...hookResponse.metadata},
         headers: [...response.headers, ...hookResponse.headers],
         body: hookResponse.body,
         statusCode: hookResponse.statusCode,
@@ -219,7 +217,6 @@ class GazelleApp {
 
     final handlerResponse = await handler(context, request);
     response = GazelleResponse(
-      metadata: {...response.metadata, ...handlerResponse.metadata},
       headers: [...response.headers, ...handlerResponse.headers],
       body: handlerResponse.body,
       statusCode: handlerResponse.statusCode,
@@ -234,11 +231,9 @@ class GazelleApp {
         bodyStream: hookRequest.bodyStream,
         method: hookRequest.method,
         headers: [...request.headers, ...hookRequest.headers],
-        metadata: {...request.metadata, ...hookRequest.metadata},
         pathParameters: hookRequest.pathParameters,
       );
       response = GazelleResponse(
-        metadata: {...response.metadata, ...hookResponse.metadata},
         headers: [...response.headers, ...hookResponse.headers],
         body: hookResponse.body,
         statusCode: hookResponse.statusCode,

--- a/packages/gazelle_core/lib/src/gazelle_handler.dart
+++ b/packages/gazelle_core/lib/src/gazelle_handler.dart
@@ -51,7 +51,6 @@ class GazelleHandler<RequestType, ResponseType> {
       uri: request.uri,
       method: request.method,
       pathParameters: request.pathParameters,
-      metadata: request.metadata,
       headers: request.headers,
       body: typedBody,
       bodyStream: request.bodyStream,

--- a/packages/gazelle_core/lib/src/gazelle_message.dart
+++ b/packages/gazelle_core/lib/src/gazelle_message.dart
@@ -5,6 +5,20 @@ import 'gazelle_http_header.dart';
 import 'gazelle_http_method.dart';
 import 'gazelle_http_status_code.dart';
 
+/// The context of a [GazelleMessage].
+class GazelleMessageContext {
+  final Map<Type, dynamic> _map;
+
+  /// Builds a [GazelleMessageContext].
+  GazelleMessageContext() : _map = {};
+
+  /// Retrieves a [T]? instance from the context.
+  T? call<T>() => _map[T] as T?;
+
+  /// Adds a [T] instance to the context.
+  void add<T>(T value) => _map[T] = value;
+}
+
 /// Represents a message exchanged between the client and the server in Gazelle.
 ///
 /// This class serves as the base class for both [GazelleRequest] and [GazelleResponse].
@@ -12,8 +26,8 @@ abstract class GazelleMessage {
   /// The headers of the message.
   final List<GazelleHttpHeader> headers;
 
-  /// Request's metadata.
-  final Map<String, dynamic> metadata;
+  /// The context of the message.
+  final GazelleMessageContext context;
 
   /// Constructs a GazelleMessage instance.
   ///
@@ -22,10 +36,9 @@ abstract class GazelleMessage {
   ///
   /// The optional parameter [metadata] represents additional metadata associated
   /// with the message, defaulting to an empty map if not provided.
-  const GazelleMessage({
+  GazelleMessage({
     this.headers = const [],
-    this.metadata = const {},
-  });
+  }) : context = GazelleMessageContext();
 }
 
 /// Represents an HTTP request in Gazelle.
@@ -67,7 +80,6 @@ class GazelleRequest<T> extends GazelleMessage {
     Stream<Uint8List>? bodyStream,
     this.body,
     super.headers = const [],
-    super.metadata = const {},
   }) : bodyStream = bodyStream ?? Stream.value(Uint8List(0));
 
   /// Constructs a [GazelleRequest] instance from an [HttpRequest].
@@ -110,11 +122,10 @@ class GazelleResponse<T> extends GazelleMessage {
   /// defaulting to an empty map if not provided.
   /// The optional [metadata] parameter represents additional metadata associated
   /// with the response, defaulting to an empty map if not provided.
-  const GazelleResponse({
+  GazelleResponse({
     this.statusCode = const GazelleHttpStatusCode.custom(200),
     this.body,
     super.headers = const [],
-    super.metadata = const {},
   });
 }
 

--- a/packages/gazelle_core/lib/src/gazelle_router.dart
+++ b/packages/gazelle_core/lib/src/gazelle_router.dart
@@ -27,11 +27,10 @@ class GazelleRouterSearchResult {
   ///
   /// The [request] parameter represents the request associated with the search result.
   /// The [route] parameter represents the route associated with the search result.
-  const GazelleRouterSearchResult({
+  GazelleRouterSearchResult({
     required this.request,
     required this.route,
-    this.response = const GazelleResponse(),
-  });
+  }) : response = GazelleResponse();
 }
 
 /// A router for managing Gazelle routes.

--- a/packages/gazelle_jwt/lib/src/gazelle_jwt_consts.dart
+++ b/packages/gazelle_jwt/lib/src/gazelle_jwt_consts.dart
@@ -1,17 +1,14 @@
-/// Keyword used for JSON Web Token (JWT) authentication.
-const jwtKeyword = "jwt";
-
 /// Name of the authorization header used for authentication.
-const authHeaderName = "authorization";
+const kAuthHeaderName = "authorization";
 
 /// Schema prefix used for Bearer token authentication.
-const bearerSchema = "Bearer ";
+const kBearerSchema = "Bearer ";
 
 /// Message indicating that the token is invalid.
-const invalidTokenMessage = "Invalid token.";
+const kInvalidTokenMessage = "Invalid token.";
 
 /// Message indicating that the authorization header is missing.
-const missingAuthHeaderMessage = "Authorization header is missing.";
+const kMissingAuthHeaderMessage = "Authorization header is missing.";
 
 /// Message indicating that the bearer schema is invalid.
-const badBearerSchemaMessage = "Bad bearer schema.";
+const kBadBearerSchemaMessage = "Bad bearer schema.";

--- a/packages/gazelle_jwt/lib/src/gazelle_jwt_extensions.dart
+++ b/packages/gazelle_jwt/lib/src/gazelle_jwt_extensions.dart
@@ -1,9 +1,11 @@
 import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:gazelle_core/gazelle_core.dart';
-import 'gazelle_jwt_consts.dart';
 
 /// An extension providing JWT-related functionality to GazelleRequest instances.
 extension GazelleJwtRequestExtension on GazelleRequest {
-  /// Retrieves the JWT from the request metadata.
-  JWT get jwt => metadata[jwtKeyword]!;
+  /// Retrieves the [JWT] from the request.
+  JWT? get jwt => context<JWT>();
+
+  /// Sets the [jwt].
+  void setJwt(JWT jwt) => context.add<JWT>(jwt);
 }

--- a/packages/gazelle_jwt/lib/src/gazelle_jwt_plugin.dart
+++ b/packages/gazelle_jwt/lib/src/gazelle_jwt_plugin.dart
@@ -1,5 +1,5 @@
-import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:gazelle_core/gazelle_core.dart';
+import '../gazelle_jwt.dart';
 import 'gazelle_jwt_consts.dart';
 
 /// A plugin for JSON Web Token (JWT) authentication in Gazelle.
@@ -67,42 +67,35 @@ class GazelleJwtPlugin implements GazellePlugin {
               request,
               GazelleResponse(
                 statusCode: GazelleHttpStatusCode.error.unauthorized_401,
-                body: missingAuthHeaderMessage,
+                body: kMissingAuthHeaderMessage,
               )
             );
           }
 
-          if (!authHeader.startsWith(bearerSchema)) {
+          if (!authHeader.startsWith(kBearerSchema)) {
             return (
               request,
               GazelleResponse(
                 statusCode: GazelleHttpStatusCode.error.unauthorized_401,
-                body: badBearerSchemaMessage,
+                body: kBadBearerSchemaMessage,
               )
             );
           }
 
-          final token = authHeader.replaceAll(bearerSchema, "");
+          final token = authHeader.replaceAll(kBearerSchema, "");
           final jwt = verify(token);
           if (jwt == null) {
             return (
               request,
               GazelleResponse(
                 statusCode: GazelleHttpStatusCode.error.unauthorized_401,
-                body: invalidTokenMessage,
+                body: kInvalidTokenMessage,
               )
             );
           }
 
           return (
-            GazelleRequest(
-              uri: request.uri,
-              method: request.method,
-              pathParameters: request.pathParameters,
-              metadata: {
-                jwtKeyword: jwt,
-              },
-            ),
+            request..setJwt(jwt),
             response,
           );
         },

--- a/packages/gazelle_jwt/test/gazelle_jwt_extensions_test.dart
+++ b/packages/gazelle_jwt/test/gazelle_jwt_extensions_test.dart
@@ -2,7 +2,6 @@ import 'dart:typed_data';
 
 import 'package:gazelle_core/gazelle_core.dart';
 import 'package:gazelle_jwt/gazelle_jwt.dart';
-import 'package:gazelle_jwt/src/gazelle_jwt_consts.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -16,11 +15,8 @@ void main() {
         uri: Uri.parse("http://localhost/test"),
         method: GazelleHttpMethod.get,
         pathParameters: {},
-        metadata: {
-          jwtKeyword: jwt,
-        },
         bodyStream: Stream.value(Uint8List(0)),
-      );
+      )..setJwt(jwt);
 
       // Act
       final result = request.jwt;

--- a/packages/gazelle_jwt/test/gazelle_jwt_test.dart
+++ b/packages/gazelle_jwt/test/gazelle_jwt_test.dart
@@ -73,7 +73,7 @@ void main() {
 
       // Assert
       expect(response.statusCode, GazelleHttpStatusCode.error.unauthorized_401);
-      expect(response.body, missingAuthHeaderMessage);
+      expect(response.body, kMissingAuthHeaderMessage);
     });
 
     test('Should return a response when header schema is invalid', () async {
@@ -101,7 +101,7 @@ void main() {
 
       // Assert
       expect(response.statusCode, GazelleHttpStatusCode.error.unauthorized_401);
-      expect(response.body, badBearerSchemaMessage);
+      expect(response.body, kBadBearerSchemaMessage);
     });
 
     test('Should return a response when token is invalid', () async {
@@ -129,7 +129,7 @@ void main() {
 
       // Assert
       expect(response.statusCode, GazelleHttpStatusCode.error.unauthorized_401);
-      expect(response.body, invalidTokenMessage);
+      expect(response.body, kInvalidTokenMessage);
     });
 
     test('Should integrate with gazelle core', () async {

--- a/packages/gazelle_jwt/test/gazelle_jwt_test.dart
+++ b/packages/gazelle_jwt/test/gazelle_jwt_test.dart
@@ -48,7 +48,7 @@ void main() {
       (request, response) = await hook(context, request, response);
 
       // Assert
-      expect(request.jwt.payload["test"], "123");
+      expect(request.jwt?.payload["test"], "123");
     });
 
     test('Should return a response when auth header is not set', () async {


### PR DESCRIPTION
Removed the `metadata` property in favor of a `GazelleMessageContext`.